### PR TITLE
 small changes + testing namespace switchable via parameters 

### DIFF
--- a/src/I18Next/Locale/Processor.php
+++ b/src/I18Next/Locale/Processor.php
@@ -47,6 +47,8 @@ final class Processor
 
         $found_key = $this->processorKey->processKey($key, $context, $counter);
 
+        //$found_key = $found_key ?? $key; // too much recursion and problem with plurals
+
         return $this->processorValue->processValue($found_key, $parameters);
     }
 

--- a/src/I18Next/Locale/Processor/Value.php
+++ b/src/I18Next/Locale/Processor/Value.php
@@ -69,7 +69,7 @@ final class Value extends AbstractProcessor
             }
 
             if (is_array($value)) {
-                $value = $value[$token[1]];
+                $value = $value[$token[1]] ?? '{{'.$index.'}}';
             }
         }
 

--- a/tests/Translator_CaseNamespace_Test.php
+++ b/tests/Translator_CaseNamespace_Test.php
@@ -52,18 +52,18 @@ class Translator_CaseNamespace_Test extends TranslatorBaseCase
     public function testNamespaceSwitch()
     {
         $this->translator->useFilenameAsNamespace(true);
-        $this->translator->setNamespacePriority('namespace3','namespace1','namespace3');
+        $this->translator->setNamespacePriority('namespace3', 'namespace1', 'namespace3');
         $this->setupTranslatorLanguages('it', 'en');
-        $result = $this->translator->_('namespace3:nskey',['namespace' => 'namespace1']);
+        $result = $this->translator->_('namespace3:nskey', ['namespace' => 'namespace1']);
         $this->assertEquals('namespace1 chiave', $result);
     }
 
     public function testNamespaceSetViaParameters()
     {
         $this->translator->useFilenameAsNamespace(true);
-        $this->translator->setNamespacePriority('namespace3','namespace1','namespace3');
+        $this->translator->setNamespacePriority('namespace3', 'namespace1', 'namespace3');
         $this->setupTranslatorLanguages('it', 'en');
-        $result = $this->translator->_('nskey',['namespace' => 'namespace1']);
+        $result = $this->translator->_('nskey', ['namespace' => 'namespace1']);
         $this->assertEquals('namespace1 chiave', $result);
     }
 

--- a/tests/Translator_CaseNamespace_Test.php
+++ b/tests/Translator_CaseNamespace_Test.php
@@ -49,6 +49,24 @@ class Translator_CaseNamespace_Test extends TranslatorBaseCase
         $this->assertEquals('namespace3 chiave', $result);
     }
 
+    public function testNamespaceSwitch()
+    {
+        $this->translator->useFilenameAsNamespace(true);
+        $this->translator->setNamespacePriority('namespace3','namespace1','namespace3');
+        $this->setupTranslatorLanguages('it', 'en');
+        $result = $this->translator->_('namespace3:nskey',['namespace' => 'namespace1']);
+        $this->assertEquals('namespace1 chiave', $result);
+    }
+
+    public function testNamespaceSetViaParameters()
+    {
+        $this->translator->useFilenameAsNamespace(true);
+        $this->translator->setNamespacePriority('namespace3','namespace1','namespace3');
+        $this->setupTranslatorLanguages('it', 'en');
+        $result = $this->translator->_('nskey',['namespace' => 'namespace1']);
+        $this->assertEquals('namespace1 chiave', $result);
+    }
+
     public function testNoPriorityWithprefixedNamespaceNoFallbackLanguage()
     {
         $this->translator->useFilenameAsNamespace(true);


### PR DESCRIPTION
Parameters can change part of the key :
prefix : Namespace
suffix : context

key = {namespace}:{key}{_context}
```
$this->translator->_('namespace3:nskey',['namespace' => 'namespace1','context' => 'other']);
// key will be namespace1:nskey_other
```
