### PR TITLE
Add piped syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.2",
-        "atk4/core": "dev-develop"
+        "atk4/core": "dev-develop",
+        "ext-json": "*"
     },
     "require-dev": {
         "atk4/data": "dev-develop",

--- a/src/I18Next/Locale/Processor/Key.php
+++ b/src/I18Next/Locale/Processor/Key.php
@@ -16,8 +16,15 @@ final class Key extends AbstractProcessor
      *
      * @return string|null
      */
-    public function processKey(string $key, ?string $context = null, ?int $counter = null)
+    public function processKey(string $key, ?string $context = null, ?int $counter = null) :?string
     {
+        $key_piped = $this->processDirectPipedKey($key, $counter);
+
+        if (null !== $key_piped)
+        {
+            return $key_piped;
+        }
+
         // if defined add context needed in any case
         if ($context) {
             $key .= '_'.$context;
@@ -31,6 +38,22 @@ final class Key extends AbstractProcessor
         return $this->processWithNamespaceWithCounter($key, $counter);
     }
 
+    private function processDirectPipedKey($key, ?int $counter = null) : ?string
+    {
+        $key_piped = explode('|', $key);
+
+        if(count($key_piped) === 1)
+        {
+            return null;
+        }
+
+        if(null === $counter || 1 === $counter)
+        {
+            return $key_piped[0];
+        }
+
+        return $key_piped[1];
+    }
     /**
      * @param string   $key
      * @param int|null $counter

--- a/src/I18Next/Locale/Processor/Key.php
+++ b/src/I18Next/Locale/Processor/Key.php
@@ -20,8 +20,7 @@ final class Key extends AbstractProcessor
     {
         $key_piped = $this->processDirectPipedKey($key, $counter);
 
-        if (null !== $key_piped)
-        {
+        if (null !== $key_piped) {
             return $key_piped;
         }
 
@@ -42,18 +41,17 @@ final class Key extends AbstractProcessor
     {
         $key_piped = explode('|', $key);
 
-        if(count($key_piped) === 1)
-        {
+        if (count($key_piped) === 1) {
             return null;
         }
 
-        if(null === $counter || 1 === $counter)
-        {
+        if (null === $counter || 1 === $counter) {
             return $key_piped[0];
         }
 
         return $key_piped[1];
     }
+
     /**
      * @param string   $key
      * @param int|null $counter

--- a/src/I18Next/atk4/TranslatorI18NextTrait.php
+++ b/src/I18Next/atk4/TranslatorI18NextTrait.php
@@ -39,7 +39,6 @@ trait TranslatorI18NextTrait
         ?string $domain = null,
         ?string $locale = null
     ): string {
-
         if (null === $this->translator) {
             throw new Exception('Translator for TranslatorI18NextTrait must be defined with setTranslator');
         }

--- a/tests/Translator_CaseDirect_Test.php
+++ b/tests/Translator_CaseDirect_Test.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace I18Next\Tests;
+
+class Translator_CaseDirect_Test extends TranslatorBaseCase
+{
+    public function testDirectPipe1()
+    {
+        $this->setupTranslatorLanguages('it', 'en');
+
+        $result = $this->translator->_('friend|friends', ['count' => 1]);
+        $this->assertEquals("friend", $result);
+    }
+
+    public function testDirectPipe3()
+    {
+        $this->setupTranslatorLanguages('it', 'en');
+
+        $result = $this->translator->_('friend|friends', ['count' => 3]);
+        $this->assertEquals("friends", $result);
+    }
+
+    public function testDirectPipe4()
+    {
+        $this->setupTranslatorLanguages('it', 'en');
+
+        $result = $this->translator->_('i have a friend|i have {{count}} friends', ['count' => 3]);
+        $this->assertEquals("i have 3 friends", $result);
+    }
+}

--- a/tests/Translator_CaseDirect_Test.php
+++ b/tests/Translator_CaseDirect_Test.php
@@ -9,7 +9,7 @@ class Translator_CaseDirect_Test extends TranslatorBaseCase
         $this->setupTranslatorLanguages('it', 'en');
 
         $result = $this->translator->_('friend|friends', ['count' => 1]);
-        $this->assertEquals("friend", $result);
+        $this->assertEquals('friend', $result);
     }
 
     public function testDirectPipe3()
@@ -17,7 +17,7 @@ class Translator_CaseDirect_Test extends TranslatorBaseCase
         $this->setupTranslatorLanguages('it', 'en');
 
         $result = $this->translator->_('friend|friends', ['count' => 3]);
-        $this->assertEquals("friends", $result);
+        $this->assertEquals('friends', $result);
     }
 
     public function testDirectPipe4()
@@ -25,6 +25,6 @@ class Translator_CaseDirect_Test extends TranslatorBaseCase
         $this->setupTranslatorLanguages('it', 'en');
 
         $result = $this->translator->_('i have a friend|i have {{count}} friends', ['count' => 3]);
-        $this->assertEquals("i have 3 friends", $result);
+        $this->assertEquals('i have 3 friends', $result);
     }
 }


### PR DESCRIPTION
Allow piped translations to be translated inline
```
$translator->_("i have a friend|i have {{count}} friends",["count" => 3]);
// output : i have 3 friends
```